### PR TITLE
forticlient - fix

### DIFF
--- a/roles/work/forticlient/templates/fctsslvpnhistory.j2
+++ b/roles/work/forticlient/templates/fctsslvpnhistory.j2
@@ -1,18 +1,13 @@
-{{ note.cfg }}
 version=2
 proxyserver=
 proxyport=
 proxyuser=
-proxypasswdenc=Enc 420d2ee65abded897a69c50f4995397969f1c1f949055d8e51
+proxypasswdenc=
 current=Travisperkins
 keepalive=0
 autostart=0
 profile=Travisperkins
-nocertwarnning=1
-p12passwdenc=Enc 420d2ee65abded897a69c50f4995397969f1c1f949055d8e51
-path=
-passwordenc=Enc 420d2ee65abded897a69c50f4995397969f1c1f949055d8e51
-user=stest
-port=39953
 server=sslvpn.travisperkins.co.uk
+port=39953
+user=stest
 


### PR DESCRIPTION
Primary bug was that the "note" to label as ansible managed is invalid in this file and thus broke the config